### PR TITLE
Update font to Blinker from Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Gittu</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Blinker:wght@100;200;300;400;600;700;800;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/custom.css">
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gittu</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/custom.css">
   </head>
   <body>

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,3 +1,8 @@
+/* Apply Barlow font to all elements */
+* {
+  font-family: 'Barlow', sans-serif !important;
+}
+
 /* Override all ::before pseudo-elements to have 35% opacity */
 *::before {
   opacity: 0.35 !important;
@@ -325,10 +330,14 @@ div[class*="banner"]::before {
   line-height: 110px !important;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5) !important;
   color: white !important;
+  font-family: 'Barlow', sans-serif !important;
+  font-weight: 700 !important;
 }
 
 /* Change the banner subtitle font size to 25px */
 .banner-subtitle {
   font-size: 25px !important;
   line-height: 35px !important;
+  font-family: 'Barlow', sans-serif !important;
+  font-weight: 500 !important;
 }

--- a/public/custom.css
+++ b/public/custom.css
@@ -1,6 +1,6 @@
-/* Apply Barlow font to all elements */
+/* Apply Blinker font to all elements */
 * {
-  font-family: 'Barlow', sans-serif !important;
+  font-family: 'Blinker', sans-serif !important;
 }
 
 /* Override all ::before pseudo-elements to have 35% opacity */
@@ -330,7 +330,7 @@ div[class*="banner"]::before {
   line-height: 110px !important;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5) !important;
   color: white !important;
-  font-family: 'Barlow', sans-serif !important;
+  font-family: 'Blinker', sans-serif !important;
   font-weight: 700 !important;
 }
 
@@ -338,6 +338,6 @@ div[class*="banner"]::before {
 .banner-subtitle {
   font-size: 25px !important;
   line-height: 35px !important;
-  font-family: 'Barlow', sans-serif !important;
+  font-family: 'Blinker', sans-serif !important;
   font-weight: 500 !important;
 }

--- a/src/assets/styles/ThemeStyles.jsx
+++ b/src/assets/styles/ThemeStyles.jsx
@@ -1,10 +1,10 @@
 const ThemeStyles = {
   fonts: {
-    body: "'Inter', sans-serif",
-    primary: "'Outfit', sans-serif",
-    secondary: "'Orbitron', sans-serif",
-    title: "'Kufam', sans-serif",
-    title2: "'Bebas Neue', sans-serif",
+    body: "'Barlow', sans-serif",
+    primary: "'Barlow', sans-serif",
+    secondary: "'Barlow', sans-serif",
+    title: "'Barlow', sans-serif",
+    title2: "'Barlow', sans-serif",
   },
 
   colors: {

--- a/src/assets/styles/ThemeStyles.jsx
+++ b/src/assets/styles/ThemeStyles.jsx
@@ -1,10 +1,10 @@
 const ThemeStyles = {
   fonts: {
-    body: "'Barlow', sans-serif",
-    primary: "'Barlow', sans-serif",
-    secondary: "'Barlow', sans-serif",
-    title: "'Barlow', sans-serif",
-    title2: "'Barlow', sans-serif",
+    body: "'Blinker', sans-serif",
+    primary: "'Blinker', sans-serif",
+    secondary: "'Blinker', sans-serif",
+    title: "'Blinker', sans-serif",
+    title2: "'Blinker', sans-serif",
   },
 
   colors: {


### PR DESCRIPTION
Changed the font from Barlow to Blinker from Google Fonts.

Updates include:
- Added Blinker Google Font to index.html
- Updated ThemeStyles.jsx to use Blinker for all font families
- Modified custom.css to apply Blinker globally and to specific elements